### PR TITLE
Provide a `psr/container` implementation decorator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,11 @@
         "php": "^8.4"
     },
     "require-dev": {
-        "ghostwriter/coding-standard": "dev-main"
+        "ghostwriter/coding-standard": "dev-main",
+        "psr/container": "^1.1 || ^2.0"
+    },
+    "provide": {
+        "psr/container-implementation": "*"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b09e2614e510638cb6d6e4a907e72b18",
+    "content-hash": "e8f274490bf707b2b25f53f65b064360",
     "packages": [],
     "packages-dev": [
         {

--- a/src/List/Aliases.php
+++ b/src/List/Aliases.php
@@ -13,6 +13,8 @@ use Ghostwriter\Container\Interface\ContainerInterface;
 use Ghostwriter\Container\Interface\ListInterface;
 use Ghostwriter\Container\Name\Alias;
 use Ghostwriter\Container\Name\Service;
+use Ghostwriter\Container\PsrContainer;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 
 use function in_array;
 
@@ -23,12 +25,18 @@ use function in_array;
 final class Aliases implements ListInterface
 {
     /**
+     * @var array<TService,TAlias>
+     */
+    public const array DEFAULT = [
+        Container::class => ContainerInterface::class,
+        PsrContainer::class => PsrContainerInterface::class,
+    ];
+
+    /**
      * @param array<TService,TAlias> $list
      */
     public function __construct(
-        private array $list = [
-            Container::class => ContainerInterface::class,
-        ],
+        private array $list = self::DEFAULT,
     ) {}
 
     public static function new(): self
@@ -38,9 +46,7 @@ final class Aliases implements ListInterface
 
     public function clear(): void
     {
-        $this->list = [
-            Container::class => ContainerInterface::class,
-        ];
+        $this->list = self::DEFAULT;
     }
 
     /**

--- a/src/PsrContainer.php
+++ b/src/PsrContainer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ghostwriter\Container;
+
+use Ghostwriter\Container\Interface\ContainerInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
+use Psr\Container\NotFoundExceptionInterface as PsrNotFoundExceptionInterface;
+use RuntimeException;
+use Throwable;
+
+final readonly class PsrContainer implements PsrContainerInterface
+{
+    public function __construct(
+        private ContainerInterface $container,
+    ) {}
+
+    public static function new(?ContainerInterface $container = null): self
+    {
+        return new self($container ?? Container::getInstance());
+    }
+
+    /**
+     * @template TObject of object
+     *
+     * @param class-string<TObject> $id
+     *
+     * @throws Throwable
+     *
+     * @return TObject
+     */
+    public function get(string $id): mixed
+    {
+        try {
+            return $this->container->get($id);
+        } catch (Throwable $e) {
+            throw new class(
+                $e::class . ': ' . $e->getMessage(),
+                $e->getCode(),
+                $e
+            ) extends RuntimeException implements PsrNotFoundExceptionInterface {};
+        }
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->container->has($id);
+    }
+}

--- a/src/PsrContainer.php
+++ b/src/PsrContainer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ghostwriter\Container;
 
 use Ghostwriter\Container\Interface\ContainerInterface;
+use Override;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Psr\Container\NotFoundExceptionInterface as PsrNotFoundExceptionInterface;
 use RuntimeException;
@@ -30,6 +31,7 @@ final readonly class PsrContainer implements PsrContainerInterface
      *
      * @return TObject
      */
+    #[Override]
     public function get(string $id): mixed
     {
         try {
@@ -43,6 +45,7 @@ final readonly class PsrContainer implements PsrContainerInterface
         }
     }
 
+    #[Override]
     public function has(string $id): bool
     {
         return $this->container->has($id);

--- a/tests/Unit/PsrContainerTest.php
+++ b/tests/Unit/PsrContainerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Ghostwriter\Container\Container;
+use Ghostwriter\Container\List\Aliases;
+use Ghostwriter\Container\List\Bindings;
+use Ghostwriter\Container\List\Builders;
+use Ghostwriter\Container\List\Dependencies;
+use Ghostwriter\Container\List\Extensions;
+use Ghostwriter\Container\List\Factories;
+use Ghostwriter\Container\List\Instances;
+use Ghostwriter\Container\List\Providers;
+use Ghostwriter\Container\List\Tags;
+use Ghostwriter\Container\Name\Alias;
+use Ghostwriter\Container\Name\Service;
+use Ghostwriter\Container\PsrContainer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
+
+#[CoversClass(Aliases::class)]
+#[CoversClass(Bindings::class)]
+#[CoversClass(Builders::class)]
+#[CoversClass(Dependencies::class)]
+#[CoversClass(Extensions::class)]
+#[CoversClass(Factories::class)]
+#[CoversClass(Instances::class)]
+#[CoversClass(Providers::class)]
+#[CoversClass(Tags::class)]
+#[CoversClass(Alias::class)]
+#[CoversClass(Service::class)]
+#[CoversClass(Container::class)]
+#[CoversClass(PsrContainer::class)]
+final class PsrContainerTest extends AbstractTestCase
+{
+    public function testGhostwriterContainerCanInstantiatePsrContainer(): void
+    {
+        self::assertInstanceOf(PsrContainer::class, $this->container->get(PsrContainerInterface::class));
+    }
+
+    public function testImplementsPsrContainerInterface(): void
+    {
+        self::assertInstanceOf(PsrContainerInterface::class, PsrContainer::new());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,7 +12,7 @@ if (! $classLoader instanceof ClassLoader) {
     throw new \RuntimeException('Class loader not found');
 }
 
-$fixturePath = __DIR__ . \DIRECTORY_SEPARATOR . 'fixture';
+$fixturePath = __DIR__ . \DIRECTORY_SEPARATOR . 'Fixture';
 
 if (\is_dir($fixturePath)) {
     /** @psalm-suppress UncaughtThrowInGlobalScope */


### PR DESCRIPTION
This pull request introduces several changes:

* Updated `composer.json` to include `psr/container` as a development dependency and provide `psr/container-implementation`.
* Added a new `PsrContainer` class that implements the `Psr\Container\ContainerInterface`.
* Created `PsrContainerTest` to ensure the new `PsrContainer` class functions correctly and implements the `Psr\Container\ContainerInterface`.
* Corrected the directory name in the `tests/bootstrap.php` file to use the correct case.