### PR TITLE
Bump `vimeo/psalm` from `6.12.0` to `6.12.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpunit/phpunit": "~12.2.6",
         "psr/container": "~1.1.2 || ~2.0.2",
         "symfony/var-dumper": "~7.3.1",
-        "vimeo/psalm": "~6.12.0"
+        "vimeo/psalm": "~6.12.1"
     },
     "provide": {
         "psr/container-implementation": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8180649288f85a81aa08e3a52a5aae58",
+    "content-hash": "baece3907684dd45b909a1748090779d",
     "packages": [],
     "packages-dev": [
         {
@@ -7248,16 +7248,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.12.0",
+            "version": "6.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2"
+                "reference": "e71404b0465be25cf7f8a631b298c01c5ddd864f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/cf420941d061a57050b6c468ef2c778faf40aee2",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e71404b0465be25cf7f8a631b298c01c5ddd864f",
+                "reference": "e71404b0465be25cf7f8a631b298c01c5ddd864f",
                 "shasum": ""
             },
             "require": {
@@ -7362,7 +7362,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-05-28T12:52:06+00:00"
+            "time": "2025-07-04T09:56:28+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Bumps `vimeo/psalm` from `6.12.0` to `6.12.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`