### PR TITLE
Update ghostwriter/coding-standard to version dev-main#62def0c

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,10 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.3.12",
+        "mockery/mockery": "~1.6.12",
+        "phpunit/phpunit": "~12.3.12",
         "psr/container": "~2.0.2",
-        "symfony/var-dumper": "^7.3.3"
+        "symfony/var-dumper": "~7.3.3"
     },
     "provide": {
         "psr/container-implementation": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c95ca414bfd80d00a7736f9228a93690",
+    "content-hash": "097601d2c659f95cfafba15a994aead7",
     "packages": [],
     "packages-dev": [
         {
@@ -766,12 +766,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225"
+                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4c9bc3e55140d0c376a3a68f561f7164699e8225",
-                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
+                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
                 "shasum": ""
             },
             "require": {
@@ -928,7 +928,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-21T13:20:26+00:00"
+            "time": "2025-09-21T14:31:25+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#4c9bc3e` to `dev-main#62def0c`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`