### PR TITLE
Update ghostwriter/coding-standard to version dev-main#995a29a

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -692,12 +692,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "ea8622b82905329bac4e11f9eb75afba75e5c3fa"
+                "reference": "995a29a75b0aae33f695c910a3be7d027148f5e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ea8622b82905329bac4e11f9eb75afba75e5c3fa",
-                "reference": "ea8622b82905329bac4e11f9eb75afba75e5c3fa",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/995a29a75b0aae33f695c910a3be7d027148f5e9",
+                "reference": "995a29a75b0aae33f695c910a3be7d027148f5e9",
                 "shasum": ""
             },
             "require": {
@@ -755,7 +755,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.7.0",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^12.5.2",
+                "phpunit/phpunit": "^12.5.3",
                 "symfony/process": "^8.0.0",
                 "symfony/var-dumper": "^8.0.0"
             },
@@ -871,7 +871,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-10T11:29:56+00:00"
+            "time": "2025-12-11T09:39:56+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#ea8622b` to `dev-main#995a29a`.

This pull request changes the following file(s): 

- Update `composer.lock`