### PR TITLE
Update boundwize/structarmed to version 0.6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.4",
+        "boundwize/structarmed": "^0.6.5",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c50cd57fc74e7a489d22df4f5e8eabb3",
+    "content-hash": "dc1f6044f0f0ea9afbee804649c0fdc1",
     "packages": [
         {
             "name": "psr/container",
@@ -63,16 +63,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.4",
+            "version": "0.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "8d630745f6e26f9c4c4d8886da913ba5264ff47b"
+                "reference": "3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/8d630745f6e26f9c4c4d8886da913ba5264ff47b",
-                "reference": "8d630745f6e26f9c4c4d8886da913ba5264ff47b",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66",
+                "reference": "3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66",
                 "shasum": ""
             },
             "require": {
@@ -121,7 +121,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.4"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.5"
             },
             "funding": [
                 {
@@ -129,7 +129,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-16T17:20:29+00:00"
+            "time": "2026-05-17T03:44:56+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -198,16 +198,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "2c20193be3316dcd85999c946d35b9051576ae97"
+                "reference": "55a42647194a75dd28eba5095c3f329de89a0306"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2c20193be3316dcd85999c946d35b9051576ae97",
-                "reference": "2c20193be3316dcd85999c946d35b9051576ae97",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/55a42647194a75dd28eba5095c3f329de89a0306",
+                "reference": "55a42647194a75dd28eba5095c3f329de89a0306",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.4",
+                "boundwize/structarmed": "^0.6.5",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -318,7 +318,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-16T17:56:23+00:00"
+            "time": "2026-05-17T03:54:31+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.4` to `0.6.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`